### PR TITLE
chore: add .gitattributes to exclude .mjs files from linguist detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mjs linguist-detectable=false


### PR DESCRIPTION
Adds `.gitattributes` to mark `.mjs` files as `linguist-detectable=false`, keeping the repo language stats accurate.

Made with [Cursor](https://cursor.com)